### PR TITLE
Point to specific andino_gz commit

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -40,9 +40,9 @@ RUN sudo apt upgrade -y && sudo apt update && rosdep update
 RUN mkdir -p /home/$USER/ros_deps_ws/src
 WORKDIR /home/$USER/ros_deps_ws/src
 # Clone andino_gz
-RUN git clone https://github.com/Ekumen-OS/andino_gz.git
+RUN git clone https://github.com/Ekumen-OS/andino_gz.git -b humble && cd andino_gz && git reset --hard 41b523aba24c6eaff114bd211edf48403678a5aa
 WORKDIR /home/$USER/ros_deps_ws
-# Clonse rmf-demos-tasks
+# Clone rmf-demos-tasks
 RUN git clone https://github.com/open-rmf/rmf_demos.git -b humble
 # Rosdep install
 RUN . /opt/ros/humble/setup.sh && rosdep install -y -i --from-paths src

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -21,6 +21,7 @@ python3-pip
 python3-setuptools
 ros-humble-andino-description
 ros-humble-andino-slam
+ros-humble-nav2-bringup
 ros-humble-nav2-common
 ros-humble-rmf-dev
 ros-humble-tf-transformations


### PR DESCRIPTION
### Summary

andino_gz migrated to use harmonic, this causes an issue with our dependencies. 
A quick fix to avoid breaking main branch is submitted to point to a working commit that still uses fortress.

This is related to #22 and should be fixed to continue bringing latest changes.